### PR TITLE
Delete a duplicated rule: `invatiant_booleans`

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -46,7 +46,6 @@ linter:
     # - do_not_use_environment
     - eol_at_end_of_file
     - flutter_style_todos
-    - invariant_booleans
     - join_return_with_assignment
     - lines_longer_than_80_chars
     - literal_only_boolean_expressions


### PR DESCRIPTION
Thank you for the great library. Your work has always helped me in my development.

I noticed this gets a warning on flutter 3.7.0-stable since it has a duplicated rule, so I just removed it.

source: https://dart-lang.github.io/linter/lints/invariant_booleans.html