### PR TITLE
Remove `require_trailing_commas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.30.3
+
+- Remove `require_trailing_commas`
+
 ## 1.30.2
 
 - Add `specify_nonobvious_property_types`

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -77,7 +77,7 @@ linter:
     - prefer_foreach
     - prefer_int_literals
     - prefer_single_quotes
-    - require_trailing_commas
+#    - require_trailing_commas
     - sized_box_shrink_expand
     - sort_constructors_first
     - sort_pub_dependencies

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pedantic_mono
 description: '[mono edition] Recommended lints for Flutter apps, packages, and plugins to encourage good coding practices.'
-version: 1.30.2
+version: 1.30.3
 repository: https://github.com/mono0926/pedantic_mono
 funding:
   - https://github.com/sponsors/mono0926


### PR DESCRIPTION
Hello mono-san,
Thank you for the great package :)
I'd be glad if you consider removing the lint rule [require_trailing_commas](https://dart.dev/tools/linter-rules/require_trailing_commas) from the list.

As Dart 3.7 introduced [the new format style](https://medium.com/dartlang/announcing-dart-3-7-bf864a1b195c#:~:text=New%20formatting%20style%20in%20the%20Dart%20formatter), the rule conflicts the formatted code in some cases.
For example, a function with positional parameters that contain list literals or function literals (a famous example is flutter_hooks [useEffect](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useEffect.html)) is cautioned by the rule. Please take a look at [the sample code](https://github.com/masa-tokyo/dart_3.29_format_sample/blob/b0dc1185c87d7346ce08fb17ffa38f6e44982a41/lib/main.dart#L26) for details.

FYI:
- This is argued in the issue [here](https://github.com/dart-lang/dart_style/issues/1253#issuecomment-2662235094).
- Another package very_good_analysis [will remove the rule](https://github.com/VeryGoodOpenSource/very_good_analysis/issues/136) also.